### PR TITLE
Implement mission joining & cancellation actions and toggle badges

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -39,6 +39,10 @@ tbody tr:nth-child(odd) {
   background-color: rgba(255, 255, 255, 0.15);
 }
 
+th {
+  padding: 1em;
+}
+
 td {
   display: table-cell;
   padding: 1em;
@@ -52,15 +56,17 @@ td {
   border-radius: 4px;
   font-size: 0.7em;
   text-align: center;
-  padding: 0.3em;
+  padding: 0.5em;
+  border: solid 1px #fff;
 }
 
 .mission-button {
-  background-color: rgba(255, 255, 255, 0);
+  background-color: #000;
   color: #fff;
   border: solid 1px #fff;
-  padding: 0.5em;
+  padding: 1em;
   font-size: 0.7em;
+  cursor: pointer;
 }
 
 .ms-name-col,
@@ -71,4 +77,16 @@ td {
 
 .ms-btn-col {
   text-align: center;
+}
+
+.reserved td p {
+  background-color: #fff;
+  color: #000;
+  font-weight: bold;
+}
+
+.reserved td button {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  border: none;
 }

--- a/src/Components/Missions.js
+++ b/src/Components/Missions.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { fetchMissons } from './redux/missions/missions';
+import { fetchMissons, updateReserved } from './redux/missions/missions';
 
 const Missions = () => {
   const fetchedMissions = useSelector((state) => state.missionSlice);
@@ -9,7 +9,9 @@ const Missions = () => {
     dispatch(fetchMissons());
   }, []);
 
-  const handleJoin = () => {};
+  const handleJoin = (missionId) => {
+    dispatch(updateReserved(missionId));
+  };
 
   return (
     <table className="missions-table">
@@ -23,20 +25,25 @@ const Missions = () => {
       </thead>
       <tbody>
         {fetchedMissions.missions.map((mission) => (
-          <tr key={mission.mission_id}>
+          <tr
+            className={mission.reserved ? 'reserved' : 'unreserved'}
+            key={mission.mission_id}
+          >
             <td className="ms-name-col">{mission.mission_name}</td>
             <td className="ms-desc-col">{mission.description}</td>
             <td className="ms-status-col">
-              <p className="mission-status">{mission.status}</p>
+              <p className="mission-status">
+                {mission.reserved ? 'Active Member' : 'NOT A MEMBER'}
+              </p>
             </td>
             <td className="ms-btn-col">
               <button
                 className="mission-button"
                 type="button"
-                onClick={handleJoin}
+                onClick={() => handleJoin(mission.mission_id)}
                 id={mission.mission_id}
               >
-                {mission.action}
+                {mission.reserved ? 'Leave Mission' : 'Join Mission'}
               </button>
             </td>
           </tr>

--- a/src/Components/redux/missions/missions.js
+++ b/src/Components/redux/missions/missions.js
@@ -12,7 +12,7 @@ export const fetchMissons = createAsyncThunk(
   async () => {
     const response = await axios.get(URL);
     return response.data;
-  }
+  },
 );
 
 const missionsSlice = createSlice({

--- a/src/Components/redux/missions/missions.js
+++ b/src/Components/redux/missions/missions.js
@@ -12,13 +12,26 @@ export const fetchMissons = createAsyncThunk(
   async () => {
     const response = await axios.get(URL);
     return response.data;
-  },
+  }
 );
 
 const missionsSlice = createSlice({
   name: 'missionSlice',
   initialState,
-  reducers: {},
+  reducers: {
+    updateReserved: (state, action) => ({
+      ...state,
+      missions: state.missions.map((thisMission) => {
+        if (thisMission.mission_id === action.payload) {
+          return {
+            ...thisMission,
+            reserved: !thisMission.reserved,
+          };
+        }
+        return thisMission;
+      }),
+    }),
+  },
   extraReducers: {
     [fetchMissons.fulfilled]: (state, action) => {
       // eslint-disable-next-line no-param-reassign
@@ -27,11 +40,12 @@ const missionsSlice = createSlice({
         mission_id: mission.mission_id,
         mission_name: mission.mission_name,
         description: mission.description,
-        status: 'NOT A MEMBER',
-        action: 'Join Mission',
+        reserved: false,
       }));
     },
   },
 });
+
+export const { updateReserved } = missionsSlice.actions;
 
 export default missionsSlice.reducer;


### PR DESCRIPTION
This pull request consists of the following;

- Dispatched an action to update the store (reserved = true) when a user clicks Join Mission
- Dispatched an action to update the store (reserved = false) when a user clicks Leave Mission
- Rendered reserved status badge to toggle between "Active Member" and "NOT A MEMBER" and the button between "Leave Mission"  and "Join Mission"